### PR TITLE
Implement Theorem 6 part 2 rule

### DIFF
--- a/src/main/kotlin/ProofSearcher.kt
+++ b/src/main/kotlin/ProofSearcher.kt
@@ -2,16 +2,18 @@ import parsing.System
 import proofs.Proof
 import proofs.RefinementTransitivity
 import proofs.SelfRefinement
+import proofs.Theorem6Conj2
 
 class ProofSearcher {
     private val theorems: Array<Proof> = arrayOf(
         RefinementTransitivity(),
-        SelfRefinement()
+        SelfRefinement(),
+        Theorem6Conj2()
     )
 
     fun findNewRelations(components: ArrayList<System>): ArrayList<System> {
         val allComponents = ArrayList<System>(components)
-        var dirtyComponents = components
+        var dirtyComponents = HashSet(components)
 
         while (dirtyComponents.isNotEmpty()) {
             dirtyComponents = searchIteration(dirtyComponents, allComponents)
@@ -21,11 +23,10 @@ class ProofSearcher {
     }
 
     private fun searchIteration(
-        dirty_components: ArrayList<System>,
+        dirty_components: HashSet<System>,
         all_components: ArrayList<System>
-    ): ArrayList<System> {
+    ): HashSet<System> {
         val context = IterationContext(all_components)
-        println("Iteration")
         for (comp in dirty_components) {
 
             for (theorem in theorems) {
@@ -38,15 +39,21 @@ class ProofSearcher {
 
     class IterationContext(components: ArrayList<System>) {
         var components = components
-        var newlyMarkedComponents = ArrayList<System>()
+        var newlyMarkedComponents = HashSet<System>()
 
         fun setDirty(component: System) {
             newlyMarkedComponents.add(component)
         }
 
-        fun addNewComponent(component: System) {
+        fun addNewComponent(component: System) : System {
+            for (comp in components) {
+                if (comp.sameAs(component)) {
+                    return comp
+                }
+            }
             components.add(component)
             newlyMarkedComponents.add(component)
+            return component
         }
     }
 

--- a/src/main/kotlin/parsing/System.kt
+++ b/src/main/kotlin/parsing/System.kt
@@ -3,10 +3,10 @@ package parsing
 import facts.RelationLoader.prefixMap
 
 interface System {
-    val refinesThis: ArrayList<System>
-    val thisRefines: ArrayList<System>
-    val notRefinesThis: ArrayList<System>
-    val thisNotRefines: ArrayList<System>
+    val refinesThis: HashSet<System>
+    val thisRefines: HashSet<System>
+    val notRefinesThis: HashSet<System>
+    val thisNotRefines: HashSet<System>
 
     fun sameAs(other: System): Boolean
 
@@ -34,17 +34,17 @@ class Component(val prefix: String, val comp: String) : System {
         assert(prefix in prefixMap) { "Unknown prefix $prefix for component $comp" }
     }
 
-    var rt = ArrayList<System>()
-    var tr = ArrayList<System>()
-    var nrt = ArrayList<System>()
-    var tnr = ArrayList<System>()
-    override val refinesThis: ArrayList<System>
+    var rt = HashSet<System>()
+    var tr = HashSet<System>()
+    var nrt = HashSet<System>()
+    var tnr = HashSet<System>()
+    override val refinesThis: HashSet<System>
         get() = rt
-    override val thisRefines: ArrayList<System>
+    override val thisRefines: HashSet<System>
         get() = tr
-    override val notRefinesThis: ArrayList<System>
+    override val notRefinesThis: HashSet<System>
         get() = nrt
-    override val thisNotRefines: ArrayList<System>
+    override val thisNotRefines: HashSet<System>
         get() = tnr
 
     override fun sameAs(other: System): Boolean {
@@ -61,34 +61,9 @@ class Component(val prefix: String, val comp: String) : System {
 
 }
 
-class Conjunction(left: System, right: System) : System {
+class Conjunction : System {
     var children = HashSet<System>()
-
-    var rt = ArrayList<System>()
-    var tr = ArrayList<System>()
-    var nrt = ArrayList<System>()
-    var tnr = ArrayList<System>()
-    override val refinesThis: ArrayList<System>
-        get() = rt
-    override val thisRefines: ArrayList<System>
-        get() = tr
-    override val notRefinesThis: ArrayList<System>
-        get() = nrt
-    override val thisNotRefines: ArrayList<System>
-        get() = tnr
-
-    override fun sameAs(other: System): Boolean {
-        if(other is Conjunction) {
-            return children == other.children
-        }
-        return false
-    }
-
-    override fun toString(): String {
-        return "(${children.joinToString(" && ")})"
-    }
-
-    init {
+    constructor(left: System, right: System) {
         if(left is Conjunction) {
             children.addAll(left.children)
         } else {
@@ -101,23 +76,66 @@ class Conjunction(left: System, right: System) : System {
         }
     }
 
+    constructor(children: HashSet<System>){
+        this.children = children
+    }
 
+    var rt = HashSet<System>()
+    var tr = HashSet<System>()
+    var nrt = HashSet<System>()
+    var tnr = HashSet<System>()
+    override val refinesThis: HashSet<System>
+        get() = rt
+    override val thisRefines: HashSet<System>
+        get() = tr
+    override val notRefinesThis: HashSet<System>
+        get() = nrt
+    override val thisNotRefines: HashSet<System>
+        get() = tnr
+
+    override fun sameAs(other: System): Boolean {
+        if(other is Conjunction) {
+            return children == other.children
+        }
+        return false
+    }
+
+    override fun toString(): String {
+        return "(${children.joinToString(" && ")})"
+    }
 }
 
-class Composition(left: System, right: System) : System {
+class Composition : System {
     var children = HashSet<System>()
 
-    var rt = ArrayList<System>()
-    var tr = ArrayList<System>()
-    var nrt = ArrayList<System>()
-    var tnr = ArrayList<System>()
-    override val refinesThis: ArrayList<System>
+    constructor(left: System, right: System) {
+        if(left is Composition) {
+            children.addAll(left.children)
+        } else {
+            children.add(left)
+        }
+        if(right is Composition) {
+            children.addAll(right.children)
+        } else {
+            children.add(right)
+        }
+    }
+
+    constructor(children: HashSet<System>){
+        this.children = children
+    }
+
+    var rt = HashSet<System>()
+    var tr = HashSet<System>()
+    var nrt = HashSet<System>()
+    var tnr = HashSet<System>()
+    override val refinesThis: HashSet<System>
         get() = rt
-    override val thisRefines: ArrayList<System>
+    override val thisRefines: HashSet<System>
         get() = tr
-    override val notRefinesThis: ArrayList<System>
+    override val notRefinesThis: HashSet<System>
         get() = nrt
-    override val thisNotRefines: ArrayList<System>
+    override val thisNotRefines: HashSet<System>
         get() = tnr
 
     override fun sameAs(other: System): Boolean {
@@ -131,16 +149,5 @@ class Composition(left: System, right: System) : System {
         return "(${children.joinToString(" || ")})"
     }
 
-    init {
-        if(left is Composition) {
-            children.addAll(left.children)
-        } else {
-            children.add(left)
-        }
-        if(right is Composition) {
-            children.addAll(right.children)
-        } else {
-            children.add(right)
-        }
-    }
+
 }

--- a/src/main/kotlin/proofs/Theorem6Conj2.kt
+++ b/src/main/kotlin/proofs/Theorem6Conj2.kt
@@ -1,0 +1,30 @@
+package proofs
+
+import parsing.Conjunction
+import parsing.System
+
+class Theorem6Conj2: Proof {
+    //HSCC.Theorem6.part2, locally consistent S, U and T: (U <= S) and (U <= T) implies U <= (S && T)
+    override fun search(component: System, ctx: ProofSearcher.IterationContext) {
+        if (component.thisRefines.size > 1) {
+            val refines = HashSet<System>()
+            refines.addAll(component.thisRefines)
+            for (lhs in refines) {
+                for (rhs in refines) {
+                    if (!lhs.sameAs(rhs)){
+                        var newComp : System = Conjunction(lhs, rhs)
+                        newComp = ctx.addNewComponent(newComp)
+                        if(newComp.refinesThis.add(component)) {
+                            ctx.setDirty(newComp)
+                        }
+                        if(component.thisRefines.add(newComp)) {
+                            ctx.setDirty(component)
+                        }
+                    }
+                }
+            }
+
+        }
+
+    }
+}

--- a/src/test/kotlin/RefinementTransitivityTest.kt
+++ b/src/test/kotlin/RefinementTransitivityTest.kt
@@ -13,9 +13,9 @@ internal class RefinementTransitivityTest {
         println("Refinements: " + refinementCount(RelationLoader.relations))
 
         var searcher = ProofSearcher()
-        searcher.findNewRelations(RelationLoader.relations)
+        var newRelation = searcher.findNewRelations(RelationLoader.relations)
 
-        println("Refinements: " + refinementCount(RelationLoader.relations))
+        println("Refinements: " + refinementCount(newRelation))
     }
 
     fun refinementCount(components: ArrayList<System>): Int{


### PR DESCRIPTION
Implements the rule from Theorem 6 part 2, changes a bunch of ArrayLists to HashSets and makes addNewComponent in IterationContext return a pointer to the previous component if it is already contained in the component list.